### PR TITLE
Updates to .travis.yml, for running python code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: node_js
 services: mongodb
-sudo: false
+sudo: true
+before_install:
+  - sudo add-apt-repository ppa:deadsnakes/ppa -y
+  - sudo apt-get update -q
+  - sudo apt-get install python3.5-dev -y
+  - sudo ln -sf /usr/bin/python3.5 /usr/bin/python
+  - sudo apt-get install python-pip -y
+install:
+  - pip install -r requirements.txt
 node_js:
   - "8"
   - "10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ before_install:
   - pip3 install -U setuptools
   - pip3 install -U virtualenvwrapper
 install:
-  - pip3 install -r requirements.txt
+  - nvm install-latest-npm
   - npm install
+  - pip3 install -r requirements.txt
 node_js:
   - "8"
   - "10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ services: mongodb
 sudo: true
 before_install:
   - sudo apt-get update -q
-  - sudo apt-get install python3-pip python-dev -y
+  - sudo apt-get install python3-pip -y
   - pip3 install -U setuptools
   - pip3 install -U virtualenvwrapper
 install:
-  - nvm install-latest-npm
+  - npm install -g npm
   - npm install
   - pip3 install -r requirements.txt
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,15 @@ language: node_js
 services: mongodb
 sudo: true
 before_install:
-  - sudo add-apt-repository ppa:deadsnakes/ppa -y
   - sudo apt-get update -q
-  - sudo apt-get install python3.5-dev -y
-  - sudo ln -sf /usr/bin/python3.5 /usr/bin/python
-  - sudo apt-get install python-pip -y
+  - sudo apt-get install python3-pip python-dev -y
+  - pip3 install -U setuptools
+  - pip3 install -U virtualenvwrapper
 install:
-  - pip install -r requirements.txt
+  - pip3 install -r requirements.txt
+  - npm install
 node_js:
   - "8"
   - "10"
+python:
+  - "3.5"

--- a/test/requirements/python-requirements.spec.js
+++ b/test/requirements/python-requirements.spec.js
@@ -1,7 +1,6 @@
 /*jshint node:true, mocha:true*/
 
 'use strict';
-var testFixture = require('../globals');
 const { spawnSync } = require('child_process');
 const assert = require('assert');
 const fs = require('fs');

--- a/test/requirements/python-requirements.spec.js
+++ b/test/requirements/python-requirements.spec.js
@@ -1,0 +1,29 @@
+/*jshint node:true, mocha:true*/
+
+'use strict';
+var testFixture = require('../globals');
+const { spawnSync } = require('child_process');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+describe('python-test', function () {
+    it('Should find python 3', (done) => {
+        const processOutput = spawnSync(`python3`, ['-c', `"print('hello world')";`]);
+        assert(processOutput.status === 0);
+        done();
+    });
+
+    describe('requirements-test', function() {
+        let requirements = fs.readFileSync(path.join(__dirname, '..', '..', 'requirements.txt'),
+            {encoding: 'utf-8'}).split('\n').filter((val) => val);
+        requirements.forEach((req) => {
+            it(`Should be able to import package ${req}`, (done) =>{
+                const processOutput = spawnSync(`python3`, ['-c', `"import ${req}";`]);
+                assert(processOutput.status === 0);
+                done();
+            });
+        });
+    });
+});
+

--- a/test/requirements/python-requirements.spec.js
+++ b/test/requirements/python-requirements.spec.js
@@ -8,8 +8,9 @@ const path = require('path');
 
 describe('python', function () {
     it('should find python 3.5', () => {
-        const processOutput = spawnSync('python3', ['-c', `import sys; assert sys.version[0:3] == '3.5'`]);
-        assert.equal(processOutput.status, 0);
+        const processOutput = spawnSync('python3', ['-c', `import sys; print(sys.version[0:3])`]);
+        const pythonVersion = processOutput.stdout.toString().trim();
+        assert.equal(pythonVersion, '3.5', `Expected python version 3.5 but found ${pythonVersion}`);
     });
 
     describe('requirements', function() {

--- a/test/requirements/python-requirements.spec.js
+++ b/test/requirements/python-requirements.spec.js
@@ -6,21 +6,19 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 
-describe('python-test', function () {
-    it('Should find python 3', (done) => {
-        const processOutput = spawnSync(`python3`, ['-c', `"print('hello world')";`]);
-        assert(processOutput.status === 0);
-        done();
+describe('python', function () {
+    it('should find python 3.5', () => {
+        const processOutput = spawnSync('python3', ['-c', `import sys; assert sys.version[0:3] == '3.5'`]);
+        assert.equal(processOutput.status, 0);
     });
 
-    describe('requirements-test', function() {
-        let requirements = fs.readFileSync(path.join(__dirname, '..', '..', 'requirements.txt'),
-            {encoding: 'utf-8'}).split('\n').filter((val) => val);
+    describe('requirements', function() {
+        const requirements = fs.readFileSync(path.join(__dirname, '..', '..', 'requirements.txt'),'utf-8').split('\n')
+            .map(line => line.trim()).filter(line => !!line);
         requirements.forEach((req) => {
-            it(`Should be able to import package ${req}`, (done) =>{
+            it(`should be able to import package ${req}`, () =>{
                 const processOutput = spawnSync(`python3`, ['-c', `"import ${req}";`]);
-                assert(processOutput.status === 0);
-                done();
+                assert.equal(processOutput.status, 0);
             });
         });
     });


### PR DESCRIPTION
This PR changes `.travis.yml` to run the python code generated by `deepforge-keras`, creating a python3.5 runtime during install. To verify requirements, a test `requirements/python-requirements.spec.js` has been added.