### PR TITLE
Update changeset version. Fixes #186

### DIFF
--- a/src/common/plugins/changeset.js
+++ b/src/common/plugins/changeset.js
@@ -42,7 +42,7 @@ function compare(path, old, new_) {
     });
 
     var delKeys = _.difference(oldKeys, newKeys);
-    delKeys.forEach(function (k) {
+    delKeys.reverse().forEach(function (k) {
       changes.push({ type: 'del', key: path.concat(k) });
     });
 
@@ -120,7 +120,6 @@ function apply(changes, target, modify) {
   });
   return obj;
 }
-
 },{"udc":3,"underscore":4}],3:[function(require,module,exports){
 (function (root, factory) {
 		"use strict";


### PR DESCRIPTION
This updates to the latest version of changeset (in my fork) which ensures that array deletions are applied in reverse order. For regular JS arrays, this isn't an issue but this is problematic when we are interacting with some getter/setter like getting members of a set in JSON Importer.