### PR TITLE
Bolden connection index on hover. Closes #230

### DIFF
--- a/src/visualizers/widgets/KerasArchEditor/Connection.js
+++ b/src/visualizers/widgets/KerasArchEditor/Connection.js
@@ -67,12 +67,14 @@ define([
 
         const strokeWidth = this.desc.dash ? 6 : 4;
         this.$path.attr('stroke-width', strokeWidth);
+        this.$indexText.attr('font-weight', 'bold');
         this.showingTooltip = true;
     };
 
     Connection.prototype.onMouseOut = function() {
         this.$tooltip.transition().attr('opacity', 0);
         this.$path.attr('stroke-width', 2);
+        this.$indexText.attr('font-weight', '');
         this.showingTooltip = false;
     };
 


### PR DESCRIPTION
This isn't a perfect fix but resolves the ambiguity in the meantime.

There still can be annoying things with the dimension text overlaying on top of the index text...